### PR TITLE
Keep the issue open only if new comments are made

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -3462,12 +3462,27 @@ const processIssues = async ({ repoToken, issueLabel, closeMessage, operationsPe
                 core.info(`Skipping ${issueType} #${issue.number} because it does not have the ${issueLabel} label`);
                 continue;
             }
-            const updatedAt = new Date(issue.updated_at).getTime();
+            let updatedAt = new Date(issue.updated_at).getTime();
+            const numComments = issue.comments;
+            const comments = await client.issues.listComments({
+                owner: github.context.repo.owner,
+                repo: github.context.repo.repo,
+                issue_number: issue.number,
+                per_page: 30,
+                page: Math.floor((numComments - 1) / 30) + 1,
+            });
+            operations += 1;
+            const lastComments = comments.data.map(l => new Date(l.created_at).getTime()).sort();
+            if (lastComments.length > 0)
+                updatedAt = lastComments[lastComments.length - 1];
             const now = new Date().getTime();
             const daysSinceUpdated = (now - updatedAt) / 1000 / 60 / 60 / 24;
             if (daysSinceUpdated < daysBeforeClose) {
                 core.info(`Skipping ${issueType} #${issue.number} because it has been updated in the last ${daysSinceUpdated} days`);
                 continue;
+            }
+            else {
+                core.info(`Closing ${issueType} #${issue.number} because it has not been updated in the last ${daysSinceUpdated} days`);
             }
             if (closeMessage) {
                 await client.issues.createComment({

--- a/dist/index.js
+++ b/dist/index.js
@@ -3481,9 +3481,6 @@ const processIssues = async ({ repoToken, issueLabel, closeMessage, operationsPe
                 core.info(`Skipping ${issueType} #${issue.number} because it has been updated in the last ${daysSinceUpdated} days`);
                 continue;
             }
-            else {
-                core.info(`Closing ${issueType} #${issue.number} because it has not been updated in the last ${daysSinceUpdated} days`);
-            }
             if (closeMessage) {
                 await client.issues.createComment({
                     owner: github.context.repo.owner,
@@ -3506,7 +3503,7 @@ const processIssues = async ({ repoToken, issueLabel, closeMessage, operationsPe
                 issue_number: issue.number,
                 name: issueLabel,
             });
-            core.info(`Closed ${issueType} #${issue.number} and removed ${issueLabel} label`);
+            core.info(`Closed ${issueType} #${issue.number} and removed ${issueLabel} label because it has not been updated in the last ${daysSinceUpdated} days`);
             operations += 2;
         }
         if (operations >= operationsPerRun) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -89,8 +89,6 @@ const processIssues = async ({
       if (daysSinceUpdated < daysBeforeClose) {
         core.info(`Skipping ${issueType} #${issue.number} because it has been updated in the last ${daysSinceUpdated} days`);
         continue;
-      } else {
-        core.info(`Closing ${issueType} #${issue.number} because it has not been updated in the last ${daysSinceUpdated} days`);
       }
 
       if (closeMessage) {
@@ -120,7 +118,7 @@ const processIssues = async ({
         name: issueLabel,
       });
 
-      core.info(`Closed ${issueType} #${issue.number} and removed ${issueLabel} label`);
+      core.info(`Closed ${issueType} #${issue.number} and removed ${issueLabel} label because it has not been updated in the last ${daysSinceUpdated} days`);
 
       operations += 2;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,13 +68,29 @@ const processIssues = async ({
         continue;
       }
 
-      const updatedAt = new Date(issue.updated_at).getTime();
+      let updatedAt = new Date(issue.updated_at).getTime();
+
+      const numComments = issue.comments;
+      const comments = await client.issues.listComments({
+        owner: github.context.repo.owner,
+        repo: github.context.repo.repo,
+        issue_number: issue.number,
+        per_page: 30,
+        page: Math.floor((numComments - 1) / 30) + 1, // the last page
+      });
+      operations += 1;
+      const lastComments = comments.data.map(l => new Date(l.created_at).getTime()).sort();
+      if (lastComments.length > 0)
+        updatedAt = lastComments[lastComments.length - 1];
+
       const now = new Date().getTime();
       const daysSinceUpdated = (now - updatedAt) / 1000 / 60 / 60 / 24;
 
       if (daysSinceUpdated < daysBeforeClose) {
         core.info(`Skipping ${issueType} #${issue.number} because it has been updated in the last ${daysSinceUpdated} days`);
         continue;
+      } else {
+        core.info(`Closing ${issueType} #${issue.number} because it has not been updated in the last ${daysSinceUpdated} days`);
       }
 
       if (closeMessage) {


### PR DESCRIPTION
Because an issue needs __reply__ from users, it's sometimes better to only consider new comments as reply. With this option, other events will not keep the issue open.